### PR TITLE
fixed cxunsavedfile Length field being incorrect size.

### DIFF
--- a/NClang/NClang.Native/NativeTopLevel.cs
+++ b/NClang/NClang.Native/NativeTopLevel.cs
@@ -30,12 +30,12 @@ namespace NClang.Natives
 		{
 			this.FileName = filename;
 			this.Contents = contents;
-			this.Length = (ulong) contents.Length;
+			this.Length = (uint) contents.Length;
 		}
 
 		public readonly string FileName;
 		public readonly string Contents;
-		public readonly ulong Length;
+		public readonly uint Length;
 	}
 
 	[StructLayout (LayoutKind.Sequential)]


### PR DESCRIPTION
This fixes the bug I emailed you about in November, if the array of Unsaved files passed to clang_reparseTranslationUnit contains more than 1 unsaved file, then the call crashes.

It was caused by the Length field being a long instead of uint, this bug showed up on Windows 64bit.
