### PR TITLE
Changed from the nupack to the dotnet packer.

### DIFF
--- a/NClang/NClang.csproj
+++ b/NClang/NClang.csproj
@@ -4,8 +4,32 @@
         <OutputType>Library</OutputType>
         <RootNamespace>NClang</RootNamespace>
         <AssemblyName>NClang</AssemblyName>
+        <AssemblyTitle>C# bindings for Clang 4.0 API for Mono and .NET Framework</AssemblyTitle>
         <DebugType>full</DebugType>
         <DebugSymbols>true</DebugSymbols>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+        <PackageId>name.atsushieno.nclang</PackageId>
+        <PackageVersion>1.0.1</PackageVersion>
+        <Authors>Atsushi Eno</Authors>
+        <Title>nclang</Title>
+        <Description>C# bindings for Clang 4.0 API for Mono and .NET Framework</Description>
+        <Copyright>(C) 2014-2018 Atsushi Eno</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/atsushieno/nclang.git</PackageProjectUrl>
+        <PackageTags>clang;interop;mono</PackageTags>
+        <PackageReleaseNotes>See github commit logs.</PackageReleaseNotes>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/atsushieno/nclang.git</RepositoryUrl>
     </PropertyGroup>
+    <ItemGroup>
+        <Content Include="..\LICENSE" Link="LICENSE">
+            <Pack>true</Pack>
+            <PackagePath>\</PackagePath>
+        </Content>
+        <Content Include="..\README.md" Link="README.md">
+            <Pack>true</Pack>
+            <PackagePath>\</PackagePath>
+        </Content>
+    </ItemGroup>
 </Project>

--- a/pack.sh
+++ b/pack.sh
@@ -1,0 +1,1 @@
+dotnet pack --configuration Release --include-symbols NClang/NClang.csproj


### PR DESCRIPTION
It partially completed because it packed without the PInvokeGenerator.
I checked up and found a problem, the old nuspec depended both NClang and PInvokeGenerator projects. But this solution is inside of NClang project. It has a cross reference issue and maybe will failure building at the CI process.
I have a propose. Pull up the PInvokeGenerator project from samples to root, splitting the package and will apply example name: "NClang.Tools."
Other idea?
